### PR TITLE
Add return instructions message after linking

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -36,9 +36,10 @@ public class LinkCommand extends Command {
         + PREFIX_TO + "p3 "
         + PREFIX_TO + "p2";
 
-    public static final String MESSAGE_SUCCESS = "Linked %1$s pet(s) to %2$s";
+    public static final String MESSAGE_SUCCESS = "Linked %1$s pet(s) to %2$s\n%3$s";
     public static final String MESSAGE_DUPLICATE_LINK =
         "This link already exists in the address book";
+    public static final String MESSAGE_RETURN_TO_MAIN_MENU = "Please enter 'list' to return to the main menu";
 
     private final Index ownerIndex;
     private final Set<Index> petIndexes;
@@ -78,7 +79,7 @@ public class LinkCommand extends Command {
         validatedLinks.forEach(model::addLink);
 
         return new CommandResult(
-          String.format(MESSAGE_SUCCESS, validatedLinks.size(), Messages.format(owner))
+          String.format(MESSAGE_SUCCESS, validatedLinks.size(), Messages.format(owner), MESSAGE_RETURN_TO_MAIN_MENU)
         );
     }
 

--- a/src/main/java/seedu/address/logic/commands/ViewToggler.java
+++ b/src/main/java/seedu/address/logic/commands/ViewToggler.java
@@ -16,7 +16,8 @@ public class ViewToggler {
     public static final String FIND_PET_COMMAND = "Find pet";
     public static final String FIND_OWNER_COMMAND = "Find owner";
     public static final String OTHER_COMMAND = "Command does not change GUI";
-    private static final String REGEX1 = "^Linked \\d+ pet\\(s\\) to .+$";
+    private static final String REGEX1 = "^Linked \\d+ pet\\(s\\) to .+\\n"
+            + Pattern.quote(LinkCommand.MESSAGE_RETURN_TO_MAIN_MENU) + "$";
     private static final String REGEX2 = "^\\d+ pet listed!$";
     private static final String REGEX3 = "^\\d+ owner listed!$";
 

--- a/src/main/java/seedu/address/model/link/Link.java
+++ b/src/main/java/seedu/address/model/link/Link.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Represents an Owner in PawPatrol.
+ * Represents the Link between an Owner and their Pets in PawPatrol.
  * Guarantees: details are present and not null, field values are validated,
  * immutable.
  */

--- a/src/test/java/seedu/address/logic/commands/LinkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LinkCommandTest.java
@@ -61,8 +61,15 @@ public class LinkCommandTest {
         Set<Index> linkIndexes = new HashSet<>(Arrays.asList(INDEX_FIRST_PET));
         CommandResult commandResult = new LinkCommand(INDEX_FIRST_OWNER, linkIndexes).execute(modelStub);
 
-        assertEquals(String.format(LinkCommand.MESSAGE_SUCCESS, linkIndexes.size(), Messages.format(validOwner)),
-            commandResult.getFeedbackToUser());
+        assertEquals(
+                String.format(
+                        LinkCommand.MESSAGE_SUCCESS,
+                        linkIndexes.size(),
+                        Messages.format(validOwner),
+                        LinkCommand.MESSAGE_RETURN_TO_MAIN_MENU
+                ),
+                commandResult.getFeedbackToUser()
+        );
         assertEquals(Arrays.asList(link), modelStub.linksAdded);
     }
 

--- a/src/test/java/seedu/address/logic/commands/ViewTogglerTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTogglerTest.java
@@ -20,7 +20,7 @@ public class ViewTogglerTest {
                 ViewToggler.LIST_BOTH_COMMAND);
 
         assertEquals(new ViewToggler(String.format(LinkCommand.MESSAGE_SUCCESS, 4,
-                        Messages.format(ALICE))).getCommandType(),
+                        Messages.format(ALICE), LinkCommand.MESSAGE_RETURN_TO_MAIN_MENU)).getCommandType(),
                 ViewToggler.LINK_OWNER_TO_PET_COMMAND);
 
         assertEquals(new ViewToggler(AddOwnerCommand.MESSAGE_SUCCESS).getCommandType(),


### PR DESCRIPTION
Adds the following line to the success message after linking owners and pets. "Please enter 'list' to return to the main menu". Fixes #159 